### PR TITLE
Fixing IOData error when request timeout.

### DIFF
--- a/lib/open_street_map/client.ex
+++ b/lib/open_street_map/client.ex
@@ -36,7 +36,7 @@ defmodule OpenStreetMap.Client do
 
   # make request
   defp fetch(url, args) do
-    case HTTPoison.get(base_url(args) <> url, headers(args)) do
+    case HTTPoison.get(base_url(args) <> url, headers(args), request_options(args)) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} -> {:ok, body}
       {:ok, %HTTPoison.Response{body: body}} -> {:error, body}
       {:error, %HTTPoison.Error{reason: reason}} -> {:error, reason}
@@ -44,6 +44,7 @@ defmodule OpenStreetMap.Client do
   end
 
   # parse result
+  defp parse({result, :timeout}, format) when format in ["json", "jsonv2"], do: {result, :timeout}
   defp parse({result, response}, format) when format in ["json", "jsonv2"], do: {result, Jason.decode!(response)}
   defp parse(response, _), do: response
 
@@ -69,6 +70,8 @@ defmodule OpenStreetMap.Client do
   defp base_url(args), do: args[:hostname] || "https://nominatim.openstreetmap.org/"
 
   defp headers(args), do: [{"Content-Type", "application/json"}, {"User-Agent", user_agent(args[:user_agent])}, {"Accept", "Application/json; Charset=utf-8"}]
+
+  defp request_options(args), do: args[:request_options] || []
 
   # define UserAgent for request
   defp user_agent(nil), do: "hex/open_street_map/#{random_string(16)}"


### PR DESCRIPTION
I encountered issues when a request timed out. The code attempted to use `Jason.decode` on a non-IOData object, resulting in an error. To address this, I implemented a new function that checks for a timeout response and skips the `Jason.decode` call. Additionally, I created a `request_options` parameter, allowing users to define specific `HttPoison` options within the `get` request.

Here is an example of the error encountered.
![image](https://github.com/kortirso/open_street_map/assets/52768341/0c003ba0-6077-4a32-84d8-78c501e2595d)

Here is a preview of the changes:
- Timeout change:
![image](https://github.com/kortirso/open_street_map/assets/52768341/81cdb68b-d3b5-4499-b2f7-67a4fbcc35a2)

- Request options change:
![image](https://github.com/kortirso/open_street_map/assets/52768341/b803e26e-12a2-49b9-b79b-4e992633be78)

